### PR TITLE
Implement G1 evidence submission prototype

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1,0 +1,303 @@
+:root {
+  color-scheme: light;
+  --bg: #f2efe7;
+  --bg-accent: #d8d1c2;
+  --ink: #1f1a17;
+  --muted: #6c5f57;
+  --card: #f9f7f2;
+  --accent: #8f4b2d;
+  --accent-2: #3b5a5a;
+  --danger: #a23b30;
+  --shadow: 0 18px 45px rgba(31, 26, 23, 0.12);
+  --border: rgba(31, 26, 23, 0.12);
+  --radius: 18px;
+  --radius-lg: 26px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Shippori Mincho", serif;
+  color: var(--ink);
+  background: radial-gradient(circle at top left, #fff8ee 0%, var(--bg) 55%, var(--bg-accent) 100%);
+  min-height: 100vh;
+}
+
+.page {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 40px 24px 60px;
+}
+
+.hero {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(220px, 1fr);
+  gap: 24px;
+  align-items: stretch;
+  margin-bottom: 32px;
+}
+
+.eyebrow {
+  font-size: 0.85rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--accent-2);
+  margin-bottom: 12px;
+}
+
+h1 {
+  font-family: "Bodoni Moda", serif;
+  font-size: clamp(2rem, 3vw, 3rem);
+  margin: 0 0 12px;
+}
+
+.lead {
+  font-size: 1rem;
+  color: var(--muted);
+  line-height: 1.7;
+  margin: 0;
+}
+
+.status-card {
+  background: var(--card);
+  border-radius: var(--radius);
+  padding: 20px;
+  box-shadow: var(--shadow);
+  border: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.status-label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--accent);
+  margin: 0;
+}
+
+.status-value {
+  font-family: "Bodoni Moda", serif;
+  font-size: 1.5rem;
+  margin: 0;
+}
+
+.status-hint {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.75);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(6px);
+}
+
+.panel-header h2 {
+  margin: 0 0 6px;
+  font-family: "Bodoni Moda", serif;
+}
+
+.panel-header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.evidence-grid {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  gap: 16px;
+}
+
+.evidence-card {
+  border-radius: 16px;
+  padding: 16px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  cursor: grab;
+  min-height: 120px;
+  position: relative;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.evidence-card:active {
+  cursor: grabbing;
+}
+
+.evidence-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 30px rgba(31, 26, 23, 0.14);
+}
+
+.evidence-card h3 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+}
+
+.evidence-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.evidence-tag {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  background: rgba(143, 75, 45, 0.12);
+  color: var(--accent);
+  font-weight: 600;
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  border-radius: 999px;
+}
+
+.scrapbook {
+  margin-top: 20px;
+  display: grid;
+  gap: 16px;
+}
+
+.slot {
+  border-radius: 16px;
+  border: 1.5px dashed rgba(31, 26, 23, 0.25);
+  background: rgba(255, 255, 255, 0.7);
+  padding: 14px;
+  min-height: 90px;
+  display: grid;
+  gap: 8px;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.slot.drag-over {
+  border-color: var(--accent-2);
+  background: rgba(59, 90, 90, 0.08);
+}
+
+.slot-label {
+  font-size: 0.85rem;
+  color: var(--accent-2);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.slot-body {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.slot-item {
+  font-weight: 600;
+  color: var(--ink);
+}
+
+.actions {
+  margin-top: 20px;
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+button {
+  font-family: "Shippori Mincho", serif;
+  border-radius: 999px;
+  padding: 10px 22px;
+  border: 1px solid transparent;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+button.primary {
+  background: var(--accent);
+  color: #fff8f0;
+  box-shadow: 0 12px 28px rgba(143, 75, 45, 0.28);
+}
+
+button.ghost {
+  background: transparent;
+  color: var(--accent-2);
+  border-color: rgba(59, 90, 90, 0.4);
+}
+
+.result {
+  margin-top: 24px;
+  padding: 16px 18px;
+  background: rgba(143, 75, 45, 0.1);
+  border-radius: 16px;
+  border: 1px solid rgba(143, 75, 45, 0.3);
+  display: none;
+}
+
+.result.show {
+  display: block;
+}
+
+.result-title {
+  margin: 0 0 6px;
+  font-weight: 600;
+}
+
+.result-body,
+.result-hint {
+  margin: 0;
+  color: var(--ink);
+}
+
+.footer {
+  margin-top: 30px;
+  color: var(--muted);
+  font-size: 0.85rem;
+  text-align: center;
+}
+
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  background: var(--ink);
+  color: #fef8f0;
+  padding: 12px 18px;
+  border-radius: 999px;
+  box-shadow: 0 16px 30px rgba(0, 0, 0, 0.25);
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (max-width: 900px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+
+  .board {
+    grid-template-columns: 1fr;
+  }
+}

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -1,0 +1,185 @@
+const evidenceItems = [
+  {
+    id: "hotel_reservation",
+    title: "ホテル予約確認",
+    category: "A",
+    summary: "2025-12-21 みなとシティホテル / 予約ID HTL-20251221-0421",
+  },
+  {
+    id: "shinkansen_eticket",
+    title: "新幹線 eチケット",
+    category: "A",
+    summary: "2025-12-21 東京→新横浜 / HIKARI 521",
+  },
+  {
+    id: "entrance_mail",
+    title: "入場受付 完了メール",
+    category: "B",
+    summary: "2025-12-21 10:05 喜多川ホール / QR発行済み",
+  },
+  {
+    id: "venue_eticket",
+    title: "電子チケット",
+    category: "B",
+    summary: "2025-12-21 13:00 喜多川ホール",
+  },
+  {
+    id: "live_photo",
+    title: "現地写真",
+    category: "C",
+    summary: "2025-12-21 18:42 裏口ポスター / EXIF付き",
+  },
+  {
+    id: "receipt_photo",
+    title: "現地レシート",
+    category: "C",
+    summary: "2025-12-21 19:10 会場近隣店舗 / 日付明記",
+  },
+];
+
+const state = {
+  selections: {
+    A: null,
+    B: null,
+    C: null,
+  },
+  submitted: false,
+};
+
+const evidenceGrid = document.getElementById("evidenceGrid");
+const submitBtn = document.getElementById("submitBtn");
+const resetBtn = document.getElementById("resetBtn");
+const result = document.getElementById("result");
+const statusValue = document.getElementById("statusValue");
+const statusHint = document.getElementById("statusHint");
+const toast = document.getElementById("toast");
+
+function renderEvidence() {
+  evidenceGrid.innerHTML = "";
+  evidenceItems.forEach((item) => {
+    const card = document.createElement("button");
+    card.type = "button";
+    card.className = "evidence-card";
+    card.draggable = true;
+    card.dataset.id = item.id;
+    card.setAttribute("aria-label", `${item.title} (${item.category})`);
+
+    card.innerHTML = `
+      <span class="evidence-tag">カテゴリ ${item.category}</span>
+      <h3>${item.title}</h3>
+      <p>${item.summary}</p>
+    `;
+
+    card.addEventListener("dragstart", (event) => {
+      event.dataTransfer.setData("text/plain", item.id);
+    });
+
+    card.addEventListener("click", () => {
+      if (state.submitted) return;
+      const slot = document.querySelector(`.slot[data-category="${item.category}"]`);
+      if (!slot) return;
+      placeItem(item, slot);
+    });
+
+    evidenceGrid.appendChild(card);
+  });
+}
+
+function attachSlotHandlers() {
+  document.querySelectorAll(".slot").forEach((slot) => {
+    slot.addEventListener("dragover", (event) => {
+      event.preventDefault();
+      if (state.submitted) return;
+      slot.classList.add("drag-over");
+    });
+
+    slot.addEventListener("dragleave", () => {
+      slot.classList.remove("drag-over");
+    });
+
+    slot.addEventListener("drop", (event) => {
+      event.preventDefault();
+      slot.classList.remove("drag-over");
+      if (state.submitted) return;
+      const id = event.dataTransfer.getData("text/plain");
+      const item = evidenceItems.find((entry) => entry.id === id);
+      if (!item) return;
+      placeItem(item, slot);
+    });
+  });
+}
+
+function placeItem(item, slot) {
+  const category = slot.dataset.category;
+  if (item.category !== category) {
+    showToast(`カテゴリ${category}には別の証拠が必要です。`);
+    return;
+  }
+
+  state.selections[category] = item.id;
+  slot.querySelector(".slot-body").innerHTML = `
+    <span class="slot-item">${item.title}</span><br />
+    <span class="slot-desc">${item.summary}</span>
+  `;
+
+  updateState();
+}
+
+function updateState() {
+  const ready = Object.values(state.selections).every(Boolean);
+  submitBtn.disabled = !ready || state.submitted;
+
+  if (state.submitted) {
+    statusValue.textContent = "提出済み";
+    statusHint.textContent = "パスワードヒントが解放されました。";
+    return;
+  }
+
+  if (ready) {
+    statusValue.textContent = "提出可能";
+    statusHint.textContent = "カテゴリA/B/Cが揃いました。";
+  } else {
+    statusValue.textContent = "未提出";
+    statusHint.textContent = "3カテゴリが揃うと提出できます。";
+  }
+}
+
+function handleSubmit() {
+  if (state.submitted) return;
+  state.submitted = true;
+  result.classList.add("show");
+  submitBtn.disabled = true;
+  showToast("3点一致を確定しました。");
+  updateState();
+}
+
+function handleReset() {
+  state.selections = { A: null, B: null, C: null };
+  state.submitted = false;
+  result.classList.remove("show");
+
+  document.querySelectorAll(".slot").forEach((slot) => {
+    const body = slot.querySelector(".slot-body");
+    if (!body) return;
+    body.innerHTML = "ここに配置";
+  });
+
+  updateState();
+}
+
+let toastTimer;
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    toast.classList.remove("show");
+  }, 2000);
+}
+
+submitBtn.addEventListener("click", handleSubmit);
+resetBtn.addEventListener("click", handleReset);
+
+renderEvidence();
+attachSlotHandlers();
+updateState();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,81 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ARG2 - Chapter 1 Evidence Board</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Chapter 1 / Evidence Alignment</p>
+        <h1>3点一致の証拠提出</h1>
+        <p class="lead">
+          死後も動いていたという違和感を、客観的な3点の証拠で確定する。
+          カテゴリA/B/Cから1つずつ選び、提出を有効化してください。
+        </p>
+      </div>
+      <div class="status-card" id="statusCard">
+        <p class="status-label">提出状況</p>
+        <p class="status-value" id="statusValue">未提出</p>
+        <p class="status-hint" id="statusHint">3カテゴリが揃うと提出できます。</p>
+      </div>
+    </header>
+
+    <main class="board">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>証拠一覧</h2>
+          <p>ドラッグまたはクリックでスクラップに配置。</p>
+        </div>
+        <div class="evidence-grid" id="evidenceGrid"></div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>スクラップボード</h2>
+          <p>カテゴリA/B/Cに1件ずつ。</p>
+        </div>
+        <div class="scrapbook" id="scrapbook">
+          <div class="slot" data-category="A">
+            <div class="slot-label">A: 交通/宿</div>
+            <div class="slot-body">ここに配置</div>
+          </div>
+          <div class="slot" data-category="B">
+            <div class="slot-label">B: 受付/入場</div>
+            <div class="slot-body">ここに配置</div>
+          </div>
+          <div class="slot" data-category="C">
+            <div class="slot-label">C: 現地証拠</div>
+            <div class="slot-body">ここに配置</div>
+          </div>
+        </div>
+
+        <div class="actions">
+          <button class="ghost" id="resetBtn" type="button">リセット</button>
+          <button class="primary" id="submitBtn" type="button" disabled>提出する</button>
+        </div>
+
+        <div class="result" id="result">
+          <p class="result-title">提出完了</p>
+          <p class="result-body">パスワードのヒントが解放されました。</p>
+          <p class="result-hint">パス: 推しの誕生日（MMDD）</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>ARG2 Prototype — Evidence Alignment (G1)</p>
+    </footer>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+  <script src="assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #3

## 概要
- G1証拠提出UI（A/B/C）を追加
- ドラッグ/クリック配置を実装
- 3カテゴリ揃うまで提出不可
- 提出後にパスワードヒントを表示

## テスト
- 未実施（静的HTML/CSS/JS）