### PR TITLE
G2: チャット復元プロトタイプを追加

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -40,6 +40,37 @@ body {
   margin-bottom: 32px;
 }
 
+.top-nav {
+  display: inline-flex;
+  gap: 12px;
+  align-items: center;
+  font-size: 0.85rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+
+.top-nav a {
+  color: var(--accent-2);
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 4px;
+}
+
+.top-nav a.active::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 2px;
+  background: var(--accent-2);
+}
+
+.nav-sep {
+  color: var(--muted);
+}
+
 .eyebrow {
   font-size: 0.85rem;
   letter-spacing: 0.18em;
@@ -95,6 +126,12 @@ h1 {
 .board {
   display: grid;
   grid-template-columns: minmax(0, 1.3fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
+.chat-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
   gap: 24px;
 }
 
@@ -292,12 +329,75 @@ button.ghost {
   transform: translateY(0);
 }
 
+.chat-window {
+  margin-top: 20px;
+  background: #fffaf1;
+  border-radius: 18px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  min-height: 320px;
+  display: grid;
+  gap: 12px;
+}
+
+.chat-line {
+  display: grid;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(143, 75, 45, 0.08);
+  border: 1px solid rgba(143, 75, 45, 0.18);
+}
+
+.chat-line.system {
+  background: rgba(59, 90, 90, 0.12);
+  border-color: rgba(59, 90, 90, 0.3);
+  color: var(--accent-2);
+}
+
+.chat-time {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.chat-who {
+  font-weight: 600;
+}
+
+.chat-text {
+  line-height: 1.5;
+}
+
+.restore-card {
+  margin-top: 18px;
+  padding: 16px;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.85);
+  display: grid;
+  gap: 8px;
+}
+
+.restore-title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.restore-desc {
+  margin: 0;
+  color: var(--muted);
+}
+
 @media (max-width: 900px) {
   .hero {
     grid-template-columns: 1fr;
   }
 
   .board {
+    grid-template-columns: 1fr;
+  }
+
+  .chat-layout {
     grid-template-columns: 1fr;
   }
 }

--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -1,0 +1,99 @@
+const chatWindow = document.getElementById("chatWindow");
+const partialRestoreBtn = document.getElementById("partialRestoreBtn");
+const fragmentBtn = document.getElementById("fragmentBtn");
+const chatResult = document.getElementById("chatResult");
+const chatStatusValue = document.getElementById("chatStatusValue");
+const chatStatusHint = document.getElementById("chatStatusHint");
+const toast = document.getElementById("toast");
+
+const baseLog = [
+  { time: "12/15 23:10", who: "自分", text: "連絡先を整理しておく" },
+  { time: "12/15 23:45", who: "自分", text: "明日は大事な日" },
+  { time: "12/16 07:30", who: "自分", text: "準備はできた" },
+  { time: "12/16 12:??", who: "system", text: "[データ欠落]" },
+  { time: "12/16 15:20", who: "自分", text: "やっと終わった" },
+  { time: "12/16 18:40", who: "自分", text: "帰路につく" },
+];
+
+const partialLog = [
+  { time: "12/15 23:45", who: "自分", text: "明日は大事な日" },
+  { time: "12/16 07:30", who: "自分", text: "準備はできた" },
+  { time: "12/16 12:??", who: "system", text: "[データ破損]" },
+  { time: "12/16 15:20", who: "自分", text: "やっと終わった" },
+];
+
+const fullLog = [
+  { time: "12/15 23:45", who: "自分", text: "明日決行する" },
+  { time: "12/16 07:30", who: "自分", text: "準備は完璧。例のものは収納ケースに入れた" },
+  { time: "12/16 12:15", who: "自分", text: "会場に着いた。警備は予想通り" },
+  { time: "12/16 12:34", who: "自分", text: "完了。北側階段、誰も見ていない" },
+  { time: "12/16 15:20", who: "自分", text: "やっと終わった。これで全部終わる" },
+  { time: "12/16 23:00", who: "自分", text: "このログを削除して差し替え版を作る" },
+];
+
+const state = {
+  stage: "missing",
+};
+
+function renderChat(log) {
+  chatWindow.innerHTML = "";
+  log.forEach((entry) => {
+    const line = document.createElement("div");
+    line.className = `chat-line ${entry.who === "system" ? "system" : "user"}`;
+    line.innerHTML = `
+      <span class="chat-time">${entry.time}</span>
+      <span class="chat-who">${entry.who}</span>
+      <span class="chat-text">${entry.text}</span>
+    `;
+    chatWindow.appendChild(line);
+  });
+}
+
+function updateStatus() {
+  if (state.stage === "missing") {
+    chatStatusValue.textContent = "欠落あり";
+    chatStatusHint.textContent = "復元を試みてください。";
+  } else if (state.stage === "partial") {
+    chatStatusValue.textContent = "部分復元";
+    chatStatusHint.textContent = "完全復元には断片データが必要です。";
+  } else {
+    chatStatusValue.textContent = "完全復元";
+    chatStatusHint.textContent = "決定打のログが復元されました。";
+  }
+}
+
+function handlePartialRestore() {
+  if (state.stage !== "missing") return;
+  state.stage = "partial";
+  renderChat(partialLog);
+  fragmentBtn.disabled = false;
+  showToast("部分復元に成功しました。");
+  updateStatus();
+}
+
+function handleFragmentLoad() {
+  if (state.stage !== "partial") return;
+  state.stage = "full";
+  renderChat(fullLog);
+  fragmentBtn.disabled = true;
+  partialRestoreBtn.disabled = true;
+  chatResult.classList.add("show");
+  showToast("完全復元が完了しました。");
+  updateStatus();
+}
+
+let toastTimer;
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    toast.classList.remove("show");
+  }, 2000);
+}
+
+partialRestoreBtn.addEventListener("click", handlePartialRestore);
+fragmentBtn.addEventListener("click", handleFragmentLoad);
+
+renderChat(baseLog);
+updateStatus();

--- a/chat.html
+++ b/chat.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ARG2 - Chapter 2 Chat Restore</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <nav class="top-nav">
+          <a href="index.html">Chapter 1</a>
+          <span class="nav-sep">/</span>
+          <a class="active" href="chat.html">Chapter 2</a>
+        </nav>
+        <p class="eyebrow">Chapter 2 / Chat Restoration</p>
+        <h1>欠落DMの復元</h1>
+        <p class="lead">
+          チャットログの欠落を発見し、段階的に復元する。
+          部分復元で違和感を生み、断片投入で完全復元へ進む。
+        </p>
+      </div>
+      <div class="status-card" id="chatStatus">
+        <p class="status-label">復元状況</p>
+        <p class="status-value" id="chatStatusValue">欠落あり</p>
+        <p class="status-hint" id="chatStatusHint">復元を試みてください。</p>
+      </div>
+    </header>
+
+    <main class="chat-layout">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>チャットログ</h2>
+          <p>欠落部分は [データ欠落] として表示されます。</p>
+        </div>
+        <div class="chat-window" id="chatWindow"></div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>復元操作</h2>
+          <p>段階的に復元を進める。</p>
+        </div>
+
+        <div class="restore-card">
+          <p class="restore-title">ステップ1: 部分復元</p>
+          <p class="restore-desc">ログの欠落部分を可能な範囲で復元する。</p>
+          <button class="primary" id="partialRestoreBtn" type="button">復元を試みる</button>
+        </div>
+
+        <div class="restore-card">
+          <p class="restore-title">ステップ2: 断片を読み込む</p>
+          <p class="restore-desc">バックアップ断片が必要です。</p>
+          <button class="ghost" id="fragmentBtn" type="button" disabled>バックアップ断片を読み込む</button>
+        </div>
+
+        <div class="result" id="chatResult">
+          <p class="result-title">完全復元成功</p>
+          <p class="result-body">欠落していたメッセージがすべて復元されました。</p>
+          <p class="result-hint">次の章で提出用の証拠として扱えます。</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>ARG2 Prototype — Chat Restoration (G2)</p>
+    </footer>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+  <script src="assets/js/chat.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -13,6 +13,11 @@
   <div class="page">
     <header class="hero">
       <div>
+        <nav class="top-nav">
+          <a class="active" href="index.html">Chapter 1</a>
+          <span class="nav-sep">/</span>
+          <a href="chat.html">Chapter 2</a>
+        </nav>
         <p class="eyebrow">Chapter 1 / Evidence Alignment</p>
         <h1>3点一致の証拠提出</h1>
         <p class="lead">


### PR DESCRIPTION
Closes #4

## 概要
- G2のチャット復元ページを追加
- 欠落表示→部分復元→断片読み込み→完全復元のステップを実装
- G1/G2のページ間ナビを追加

## テスト
- 未実施（静的HTML/CSS/JS）