### PR TITLE
G3: 旧版復元と差分表示を追加

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -135,6 +135,12 @@ h1 {
   gap: 24px;
 }
 
+.version-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
+  gap: 24px;
+}
+
 .panel {
   background: rgba(255, 255, 255, 0.75);
   border-radius: var(--radius-lg);
@@ -388,6 +394,83 @@ button.ghost {
   color: var(--muted);
 }
 
+.toggle-row {
+  margin-top: 18px;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.file-list {
+  margin-top: 18px;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.file-list.hidden {
+  display: none;
+}
+
+.file-item {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.file-item.highlight {
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.diff {
+  margin-top: 18px;
+  display: none;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.diff.show {
+  display: grid;
+}
+
+.diff-column {
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 14px;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+.diff-title {
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+
+.diff-body {
+  display: grid;
+  gap: 8px;
+}
+
+.diff-line {
+  padding: 8px 10px;
+  border-radius: 12px;
+  background: rgba(143, 75, 45, 0.08);
+  border: 1px solid rgba(143, 75, 45, 0.18);
+}
+
+.diff-line.highlight {
+  background: rgba(162, 59, 48, 0.12);
+  border-color: rgba(162, 59, 48, 0.4);
+  color: var(--danger);
+}
+
+.diff-line.muted {
+  background: rgba(59, 90, 90, 0.1);
+  border-color: rgba(59, 90, 90, 0.2);
+  color: var(--accent-2);
+}
+
 @media (max-width: 900px) {
   .hero {
     grid-template-columns: 1fr;
@@ -398,6 +481,10 @@ button.ghost {
   }
 
   .chat-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .version-layout {
     grid-template-columns: 1fr;
   }
 }

--- a/assets/js/version.js
+++ b/assets/js/version.js
@@ -1,0 +1,94 @@
+const toggleHiddenBtn = document.getElementById("toggleHiddenBtn");
+const hiddenFiles = document.getElementById("hiddenFiles");
+const hiddenStatus = document.getElementById("hiddenStatus");
+const hiddenHint = document.getElementById("hiddenHint");
+const compareBtn = document.getElementById("compareBtn");
+const diffPanel = document.getElementById("diffPanel");
+const diffLeft = document.getElementById("diffLeft");
+const diffRight = document.getElementById("diffRight");
+const diffResult = document.getElementById("diffResult");
+const toast = document.getElementById("toast");
+
+const v1Lines = [
+  "12/09時点のメモ:",
+  "12/16 12:34、北側階段で悲鳴が聞こえたはず。",
+  "血痕は階段の3段目あたりに残る可能性。",
+  "関係者Aが北側に向かったのは昼過ぎ。",
+  "控室の鍵は二つある。予備は受付の引き出し。",
+  "私のアリバイ写真は昼前に撮っておく。",
+];
+
+const v2Lines = [
+  "調査メモ（改訂版）:",
+  "当日の動線はまだ確証がない。",
+  "血痕位置については現時点で不明。",
+  "関係者Aの行動は記録不足のため断定できない。",
+  "控室の鍵の所在は未確認。",
+  "アリバイ写真は別途保管済み。",
+];
+
+const highlightIndexes = [1, 2, 4];
+
+const state = {
+  hiddenShown: false,
+  compared: false,
+};
+
+function renderDiff() {
+  diffLeft.innerHTML = v1Lines
+    .map((line, index) => {
+      const highlight = highlightIndexes.includes(index) ? "highlight" : "";
+      return `<div class="diff-line ${highlight}">${line}</div>`;
+    })
+    .join("");
+
+  diffRight.innerHTML = v2Lines
+    .map((line, index) => {
+      const highlight = highlightIndexes.includes(index) ? "muted" : "";
+      return `<div class="diff-line ${highlight}">${line}</div>`;
+    })
+    .join("");
+}
+
+function updateHiddenState() {
+  if (state.hiddenShown) {
+    hiddenFiles.classList.remove("hidden");
+    hiddenStatus.textContent = "表示中";
+    hiddenHint.textContent = "旧版メモが見つかりました。";
+  } else {
+    hiddenFiles.classList.add("hidden");
+    hiddenStatus.textContent = "未表示";
+    hiddenHint.textContent = "オプションを有効化してください。";
+  }
+}
+
+function handleToggleHidden() {
+  state.hiddenShown = true;
+  toggleHiddenBtn.disabled = true;
+  updateHiddenState();
+  showToast("隠しファイルを表示しました。");
+}
+
+function handleCompare() {
+  if (!state.hiddenShown || state.compared) return;
+  state.compared = true;
+  renderDiff();
+  diffPanel.classList.add("show");
+  diffResult.classList.add("show");
+  showToast("矛盾箇所をハイライトしました。");
+}
+
+let toastTimer;
+function showToast(message) {
+  toast.textContent = message;
+  toast.classList.add("show");
+  clearTimeout(toastTimer);
+  toastTimer = setTimeout(() => {
+    toast.classList.remove("show");
+  }, 2000);
+}
+
+compareBtn.addEventListener("click", handleCompare);
+toggleHiddenBtn.addEventListener("click", handleToggleHidden);
+
+updateHiddenState();

--- a/chapter3.html
+++ b/chapter3.html
@@ -1,0 +1,94 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ARG2 - Chapter 3 Version Restore</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <nav class="top-nav">
+          <a href="index.html">Chapter 1</a>
+          <span class="nav-sep">/</span>
+          <a href="chat.html">Chapter 2</a>
+          <span class="nav-sep">/</span>
+          <a class="active" href="chapter3.html">Chapter 3</a>
+        </nav>
+        <p class="eyebrow">Chapter 3 / Version Restore</p>
+        <h1>旧版復元と矛盾の確定</h1>
+        <p class="lead">
+          隠しフォルダを表示し、旧版メモを復元する。
+          v1とv2の差分から事前知識の矛盾を確定する。
+        </p>
+      </div>
+      <div class="status-card">
+        <p class="status-label">隠しファイル</p>
+        <p class="status-value" id="hiddenStatus">未表示</p>
+        <p class="status-hint" id="hiddenHint">オプションを有効化してください。</p>
+      </div>
+    </header>
+
+    <main class="version-layout">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>ファイル一覧</h2>
+          <p>隠しファイルを表示すると `.version_history/` が見つかります。</p>
+        </div>
+
+        <div class="toggle-row">
+          <button class="primary" id="toggleHiddenBtn" type="button">隠しファイルを表示</button>
+        </div>
+
+        <div class="file-list" id="fileList">
+          <div class="file-item">Documents/Notes/investigation_notes_v2.txt</div>
+          <div class="file-item">Documents/Notes/schedule_notes.txt</div>
+          <div class="file-item">Documents/Browser/official_announcement.html</div>
+        </div>
+
+        <div class="file-list hidden" id="hiddenFiles">
+          <div class="file-item highlight">Documents/.version_history/investigation_notes_v1.txt</div>
+          <button class="ghost" id="compareBtn" type="button">v1とv2を比較する</button>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>差分比較</h2>
+          <p>事前知識の矛盾箇所がハイライトされます。</p>
+        </div>
+
+        <div class="diff" id="diffPanel">
+          <div class="diff-column">
+            <div class="diff-title">v1（旧版）</div>
+            <div class="diff-body" id="diffLeft"></div>
+          </div>
+          <div class="diff-column">
+            <div class="diff-title">v2（現行）</div>
+            <div class="diff-body" id="diffRight"></div>
+          </div>
+        </div>
+
+        <div class="result" id="diffResult">
+          <p class="result-title">矛盾を確定</p>
+          <p class="result-body">事件当日にしか知り得ない情報が旧版に含まれていた。</p>
+          <p class="result-hint">この証拠は裁定ボードで必須になります。</p>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>ARG2 Prototype — Version Restore (G3)</p>
+    </footer>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+  <script src="assets/js/version.js"></script>
+</body>
+</html>

--- a/chat.html
+++ b/chat.html
@@ -17,6 +17,8 @@
           <a href="index.html">Chapter 1</a>
           <span class="nav-sep">/</span>
           <a class="active" href="chat.html">Chapter 2</a>
+          <span class="nav-sep">/</span>
+          <a href="chapter3.html">Chapter 3</a>
         </nav>
         <p class="eyebrow">Chapter 2 / Chat Restoration</p>
         <h1>欠落DMの復元</h1>

--- a/index.html
+++ b/index.html
@@ -17,6 +17,8 @@
           <a class="active" href="index.html">Chapter 1</a>
           <span class="nav-sep">/</span>
           <a href="chat.html">Chapter 2</a>
+          <span class="nav-sep">/</span>
+          <a href="chapter3.html">Chapter 3</a>
         </nav>
         <p class="eyebrow">Chapter 1 / Evidence Alignment</p>
         <h1>3点一致の証拠提出</h1>


### PR DESCRIPTION
Closes #5

## 概要
- G3の旧版復元ページを追加
- 隠しファイル表示→旧版発見→差分表示の流れを実装
- G1/G2/G3のナビを接続

## テスト
- 未実施（静的HTML/CSS/JS）