### PR TITLE
G6: 4アプリ骨格と章解放を追加

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -129,6 +129,105 @@ h1 {
   gap: 24px;
 }
 
+.app-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 24px;
+}
+
+.chapter-selector {
+  margin-top: 18px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.chapter-selector button {
+  background: rgba(143, 75, 45, 0.1);
+  color: var(--ink);
+  border-color: rgba(143, 75, 45, 0.3);
+}
+
+.chapter-selector button.active {
+  background: var(--accent);
+  color: #fff8f0;
+  border-color: transparent;
+}
+
+.app-grid {
+  margin-top: 20px;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.app-card {
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  color: var(--ink);
+  display: grid;
+  gap: 8px;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.app-card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 30px rgba(31, 26, 23, 0.12);
+}
+
+.app-card span {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.locked-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(31, 26, 23, 0.65);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 10;
+}
+
+.locked-overlay.show {
+  display: flex;
+}
+
+.locked-card {
+  background: #fff7ee;
+  border-radius: 24px;
+  padding: 24px;
+  max-width: 420px;
+  text-align: center;
+  border: 1px solid rgba(31, 26, 23, 0.12);
+}
+
+.locked-title {
+  margin: 0 0 8px;
+  font-weight: 600;
+}
+
+.locked-message,
+.locked-action {
+  margin: 0;
+  color: var(--muted);
+}
+
+body.locked .page {
+  pointer-events: none;
+  filter: blur(2px);
+}
+
+.feature-locked {
+  opacity: 0.5;
+  filter: grayscale(0.3);
+}
+
 .chat-layout {
   display: grid;
   grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);

--- a/assets/js/chapter.js
+++ b/assets/js/chapter.js
@@ -1,0 +1,88 @@
+const CHAPTER_KEY = "arg2Chapter";
+
+function getChapter() {
+  const value = Number(localStorage.getItem(CHAPTER_KEY));
+  return Number.isNaN(value) ? 0 : value;
+}
+
+function setChapter(chapter) {
+  localStorage.setItem(CHAPTER_KEY, String(chapter));
+}
+
+function updateChapterBadge() {
+  const badge = document.querySelector("[data-chapter-badge]");
+  if (!badge) return;
+  badge.textContent = `Chapter ${getChapter()}`;
+}
+
+function applyGate() {
+  const required = Number(document.body.dataset.requiredChapter || "0");
+  if (Number.isNaN(required) || required <= 0) {
+    updateChapterBadge();
+    applyFeatureGates();
+    return;
+  }
+
+  const current = getChapter();
+  updateChapterBadge();
+
+  if (current >= required) {
+    applyFeatureGates();
+    return;
+  }
+
+  const overlay = document.querySelector(".locked-overlay");
+  if (overlay) {
+    overlay.classList.add("show");
+    overlay.querySelector(".locked-message").textContent =
+      `このページは Chapter ${required} で解放されます。`;
+    overlay.querySelector(".locked-action").textContent =
+      `現在の章: Chapter ${current}`;
+  }
+
+  document.body.classList.add("locked");
+  applyFeatureGates();
+}
+
+function attachChapterSelector() {
+  const buttons = document.querySelectorAll("[data-set-chapter]");
+  if (!buttons.length) return;
+
+  buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const value = Number(button.dataset.setChapter || "0");
+      setChapter(value);
+      updateChapterBadge();
+      document.querySelectorAll("[data-set-chapter]").forEach((btn) => {
+        btn.classList.toggle("active", btn.dataset.setChapter === String(value));
+      });
+    });
+  });
+
+  const current = getChapter();
+  buttons.forEach((btn) => {
+    btn.classList.toggle("active", btn.dataset.setChapter === String(current));
+  });
+}
+
+function applyFeatureGates() {
+  const current = getChapter();
+  document.querySelectorAll("[data-feature-chapter]").forEach((element) => {
+    const required = Number(element.dataset.featureChapter || "0");
+    if (Number.isNaN(required) || required <= current) {
+      element.classList.remove("feature-locked");
+      if (element.tagName === "BUTTON") {
+        element.disabled = false;
+      }
+      return;
+    }
+
+    element.classList.add("feature-locked");
+    if (element.tagName === "BUTTON") {
+      element.disabled = true;
+    }
+  });
+}
+
+applyGate();
+attachChapterSelector();

--- a/browser.html
+++ b/browser.html
@@ -1,0 +1,73 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ARG2 - Browser</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <nav class="top-nav">
+          <a href="desktop.html">Desktop</a>
+          <span class="nav-sep">/</span>
+          <a href="explorer.html">Explorer</a>
+          <span class="nav-sep">/</span>
+          <a class="active" href="browser.html">Browser</a>
+          <span class="nav-sep">/</span>
+          <a href="notes.html">Notes</a>
+          <span class="nav-sep">/</span>
+          <a href="chat.html">Chat</a>
+        </nav>
+        <p class="eyebrow">Browser</p>
+        <h1>公式発表と履歴</h1>
+        <p class="lead">
+          公式発表の魚拓と検索履歴から、調査の痕跡を追う。
+        </p>
+      </div>
+      <div class="status-card">
+        <p class="status-label">現在の章</p>
+        <p class="status-value" data-chapter-badge>Chapter 0</p>
+        <p class="status-hint">公式発表は Chapter 2 で重要。</p>
+      </div>
+    </header>
+
+    <main class="app-layout">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>公式発表</h2>
+          <p>魚拓ページ（仮）</p>
+        </div>
+        <div class="file-list" data-feature-chapter="2">
+          <div class="file-item">2025-12-17 10:00</div>
+          <div class="file-item">喜多川ホールで事故発生</div>
+          <div class="file-item">北側階段 12:34頃</div>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>履歴</h2>
+          <p>調査対象の検索履歴</p>
+        </div>
+        <div class="file-list">
+          <div class="file-item">喜多川ホール 導線</div>
+          <div class="file-item">警備 配置 2025</div>
+          <div class="file-item">階段 北側 カメラ</div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>ARG2 Prototype — Browser</p>
+    </footer>
+  </div>
+
+  <script src="assets/js/chapter.js"></script>
+</body>
+</html>

--- a/chapter3.html
+++ b/chapter3.html
@@ -9,11 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/css/styles.css" />
 </head>
-<body>
+<body data-required-chapter="3">
   <div class="page">
     <header class="hero">
       <div>
         <nav class="top-nav">
+          <a href="desktop.html">Desktop</a>
+          <span class="nav-sep">/</span>
           <a href="index.html">Chapter 1</a>
           <span class="nav-sep">/</span>
           <a href="chat.html">Chapter 2</a>
@@ -87,8 +89,17 @@
     </footer>
   </div>
 
+  <div class="locked-overlay">
+    <div class="locked-card">
+      <p class="locked-title">ロック中</p>
+      <p class="locked-message">このページは Chapter 3 で解放されます。</p>
+      <p class="locked-action">現在の章: Chapter 0</p>
+    </div>
+  </div>
+
   <div class="toast" id="toast"></div>
 
+  <script src="assets/js/chapter.js"></script>
   <script src="assets/js/version.js"></script>
 </body>
 </html>

--- a/chat.html
+++ b/chat.html
@@ -9,11 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/css/styles.css" />
 </head>
-<body>
+<body data-required-chapter="2">
   <div class="page">
     <header class="hero">
       <div>
         <nav class="top-nav">
+          <a href="desktop.html">Desktop</a>
+          <span class="nav-sep">/</span>
           <a href="index.html">Chapter 1</a>
           <span class="nav-sep">/</span>
           <a class="active" href="chat.html">Chapter 2</a>
@@ -74,8 +76,17 @@
     </footer>
   </div>
 
+  <div class="locked-overlay">
+    <div class="locked-card">
+      <p class="locked-title">ロック中</p>
+      <p class="locked-message">このページは Chapter 2 で解放されます。</p>
+      <p class="locked-action">現在の章: Chapter 0</p>
+    </div>
+  </div>
+
   <div class="toast" id="toast"></div>
 
+  <script src="assets/js/chapter.js"></script>
   <script src="assets/js/chat.js"></script>
 </body>
 </html>

--- a/desktop.html
+++ b/desktop.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ARG2 - Desktop</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Desktop</p>
+        <h1>仮想デスクトップ</h1>
+        <p class="lead">
+          4つのアプリを開き、必要な証拠と情報を集める。
+          章の進行はこのページから切り替えられます。
+        </p>
+        <div class="chapter-selector">
+          <button type="button" data-set-chapter="0">Chapter 0</button>
+          <button type="button" data-set-chapter="1">Chapter 1</button>
+          <button type="button" data-set-chapter="2">Chapter 2</button>
+          <button type="button" data-set-chapter="3">Chapter 3</button>
+        </div>
+      </div>
+      <div class="status-card">
+        <p class="status-label">現在の章</p>
+        <p class="status-value" data-chapter-badge>Chapter 0</p>
+        <p class="status-hint">章の進行に合わせて機能が解放されます。</p>
+      </div>
+    </header>
+
+    <main class="app-layout">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>アプリ</h2>
+          <p>4アプリのみ。追加アプリはありません。</p>
+        </div>
+        <div class="app-grid">
+          <a class="app-card" href="explorer.html">
+            <strong>Explorer</strong>
+            <span>ファイル一覧・検索・隠しファイル表示</span>
+          </a>
+          <a class="app-card" href="browser.html">
+            <strong>Browser</strong>
+            <span>公式発表と履歴を閲覧</span>
+          </a>
+          <a class="app-card" href="notes.html">
+            <strong>Notes</strong>
+            <span>調査メモや差分の確認</span>
+          </a>
+          <a class="app-card" href="chat.html">
+            <strong>Chat</strong>
+            <span>欠落DMの復元</span>
+          </a>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>進行ボード</h2>
+          <p>章ごとのギミックはここから確認。</p>
+        </div>
+        <div class="app-grid">
+          <a class="app-card" href="index.html">
+            <strong>Chapter 1: 3点一致</strong>
+            <span>証拠提出ボードへ</span>
+          </a>
+          <a class="app-card" href="chat.html">
+            <strong>Chapter 2: 欠落DM</strong>
+            <span>復元フェーズへ</span>
+          </a>
+          <a class="app-card" href="chapter3.html">
+            <strong>Chapter 3: 旧版復元</strong>
+            <span>差分比較へ</span>
+          </a>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>ARG2 Prototype — Desktop</p>
+    </footer>
+  </div>
+
+  <script src="assets/js/chapter.js"></script>
+</body>
+</html>

--- a/explorer.html
+++ b/explorer.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ARG2 - Explorer</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <nav class="top-nav">
+          <a href="desktop.html">Desktop</a>
+          <span class="nav-sep">/</span>
+          <a class="active" href="explorer.html">Explorer</a>
+          <span class="nav-sep">/</span>
+          <a href="browser.html">Browser</a>
+          <span class="nav-sep">/</span>
+          <a href="notes.html">Notes</a>
+          <span class="nav-sep">/</span>
+          <a href="chat.html">Chat</a>
+        </nav>
+        <p class="eyebrow">Explorer</p>
+        <h1>ファイル探索</h1>
+        <p class="lead">
+          フォルダ構造を辿り、証拠の所在を確認する。
+          隠しファイルは Chapter 3 で解放される。
+        </p>
+      </div>
+      <div class="status-card">
+        <p class="status-label">現在の章</p>
+        <p class="status-value" data-chapter-badge>Chapter 0</p>
+        <p class="status-hint">隠しフォルダは後半で解放。</p>
+      </div>
+    </header>
+
+    <main class="app-layout">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>ファイル一覧（抜粋）</h2>
+          <p>主要なフォルダのみを表示。</p>
+        </div>
+        <div class="file-list">
+          <div class="file-item">Documents/CASE.zip</div>
+          <div class="file-item">Documents/Photos/</div>
+          <div class="file-item">Documents/Receipts/</div>
+          <div class="file-item">Documents/Tickets/</div>
+          <div class="file-item">Documents/Notes/</div>
+        </div>
+
+        <div class="toggle-row">
+          <button class="ghost" type="button" data-feature-chapter="3">
+            隠しファイルを表示
+          </button>
+        </div>
+        <p class="lead" data-feature-chapter="3">.version_history/ と .sync_cache/ が見つかります。</p>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>ARG2 Prototype — Explorer</p>
+    </footer>
+  </div>
+
+  <script src="assets/js/chapter.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -9,11 +9,13 @@
   <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
   <link rel="stylesheet" href="assets/css/styles.css" />
 </head>
-<body>
+<body data-required-chapter="1">
   <div class="page">
     <header class="hero">
       <div>
         <nav class="top-nav">
+          <a href="desktop.html">Desktop</a>
+          <span class="nav-sep">/</span>
           <a class="active" href="index.html">Chapter 1</a>
           <span class="nav-sep">/</span>
           <a href="chat.html">Chapter 2</a>
@@ -81,8 +83,17 @@
     </footer>
   </div>
 
+  <div class="locked-overlay">
+    <div class="locked-card">
+      <p class="locked-title">ロック中</p>
+      <p class="locked-message">このページは Chapter 1 で解放されます。</p>
+      <p class="locked-action">現在の章: Chapter 0</p>
+    </div>
+  </div>
+
   <div class="toast" id="toast"></div>
 
+  <script src="assets/js/chapter.js"></script>
   <script src="assets/js/app.js"></script>
 </body>
 </html>

--- a/notes.html
+++ b/notes.html
@@ -1,0 +1,74 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ARG2 - Notes</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Bodoni+Moda:opsz,wght@6..96,500;6..96,700&family=Shippori+Mincho:wght@400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/styles.css" />
+</head>
+<body>
+  <div class="page">
+    <header class="hero">
+      <div>
+        <nav class="top-nav">
+          <a href="desktop.html">Desktop</a>
+          <span class="nav-sep">/</span>
+          <a href="explorer.html">Explorer</a>
+          <span class="nav-sep">/</span>
+          <a href="browser.html">Browser</a>
+          <span class="nav-sep">/</span>
+          <a class="active" href="notes.html">Notes</a>
+          <span class="nav-sep">/</span>
+          <a href="chat.html">Chat</a>
+        </nav>
+        <p class="eyebrow">Notes</p>
+        <h1>調査メモ</h1>
+        <p class="lead">
+          現行版の調査メモを読み、違和感を探す。
+          旧版との差分は Chapter 3 で解放される。
+        </p>
+      </div>
+      <div class="status-card">
+        <p class="status-label">現在の章</p>
+        <p class="status-value" data-chapter-badge>Chapter 0</p>
+        <p class="status-hint">差分比較は後半で解放。</p>
+      </div>
+    </header>
+
+    <main class="app-layout">
+      <section class="panel">
+        <div class="panel-header">
+          <h2>investigation_notes_v2.txt</h2>
+          <p>読ませる文章の現行版。</p>
+        </div>
+        <div class="file-list">
+          <div class="file-item">結論: 公式発表は不自然だ。関係者Aの動きが説明できない。</div>
+          <div class="file-item">控室の出入り記録が「記録なし」なのはおかしい。</div>
+          <div class="file-item">当日の映像は公開されていない。</div>
+        </div>
+      </section>
+
+      <section class="panel" data-feature-chapter="3">
+        <div class="panel-header">
+          <h2>旧版との差分</h2>
+          <p>v1との矛盾箇所を確認する。</p>
+        </div>
+        <div class="file-list">
+          <div class="file-item">12/16 12:34 北側階段の悲鳴（事前知識）</div>
+          <div class="file-item">血痕位置の具体的記述</div>
+          <div class="file-item">控室の鍵の所在</div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>ARG2 Prototype — Notes</p>
+    </footer>
+  </div>
+
+  <script src="assets/js/chapter.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #6

## 概要
- Desktop/Explorer/Browser/Notes の4アプリ骨格を追加
- 章切り替え（localStorage）と章バッジを実装
- Chapter 1/2/3 ページにロック表示を追加
- アプリ内の一部機能を章でゲート

## テスト
- 未実施（静的HTML/CSS/JS）